### PR TITLE
Allow Tests In Container Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,5 @@
 .gitattributes
 .gitignore
 Dockerfile
-test
 node_modules
 src/conf/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ## Docker file to build app as container
 
-#FROM usgs/hazdev-base-images:latest-node as node-libcurl-build
-FROM usgs/hazdev-base-images:latest-node
+FROM usgs/hazdev-base-images:latest-node as node-libcurl-build
+#FROM usgs/hazdev-base-images:latest-node
 
 # node-libcurl build dependencies
 RUN yum groupinstall -y 'Development Tools' && \
@@ -28,16 +28,16 @@ RUN /bin/bash --login -c " \
 
 ## Docker file to build app as container
 
-#FROM usgs/hazdev-base-images:latest-node
-#MAINTAINER "Eric Martinez" <emartinez@usgs.gov>
-#LABEL dockerfile_version="v0.1.1"
+FROM usgs/hazdev-base-images:latest-node
+MAINTAINER "Eric Martinez" <emartinez@usgs.gov>
+LABEL dockerfile_version="v0.1.1"
 
 # Copy application (ignores set in .dockerignore) and set permissions
-#COPY --from=node-libcurl-build /hazdev-project /hazdev-project
-#RUN chown -R hazdev-user:hazdev-user /hazdev-project
+COPY --from=node-libcurl-build /hazdev-project /hazdev-project
+RUN chown -R hazdev-user:hazdev-user /hazdev-project
 
 # Switch to hazdev-user
-#USER hazdev-user
+USER hazdev-user
 
 
 WORKDIR /hazdev-project

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ## Docker file to build app as container
 
 FROM usgs/hazdev-base-images:latest-node as node-libcurl-build
-#FROM usgs/hazdev-base-images:latest-node
 
 # node-libcurl build dependencies
 RUN yum groupinstall -y 'Development Tools' && \
@@ -24,6 +23,7 @@ RUN /bin/bash --login -c " \
             $HOME/.npm \
             /tmp/npm* \
         "
+
 
 
 ## Docker file to build app as container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ## Docker file to build app as container
 
-FROM usgs/hazdev-base-images:latest-node as node-libcurl-build
+#FROM usgs/hazdev-base-images:latest-node as node-libcurl-build
+FROM usgs/hazdev-base-images:latest-node
 
 # node-libcurl build dependencies
 RUN yum groupinstall -y 'Development Tools' && \
@@ -25,19 +26,18 @@ RUN /bin/bash --login -c " \
         "
 
 
-
 ## Docker file to build app as container
 
-FROM usgs/hazdev-base-images:latest-node
-MAINTAINER "Eric Martinez" <emartinez@usgs.gov>
-LABEL dockerfile_version="v0.1.1"
+#FROM usgs/hazdev-base-images:latest-node
+#MAINTAINER "Eric Martinez" <emartinez@usgs.gov>
+#LABEL dockerfile_version="v0.1.1"
 
 # Copy application (ignores set in .dockerignore) and set permissions
-COPY --from=node-libcurl-build /hazdev-project /hazdev-project
-RUN chown -R hazdev-user:hazdev-user /hazdev-project
+#COPY --from=node-libcurl-build /hazdev-project /hazdev-project
+#RUN chown -R hazdev-user:hazdev-user /hazdev-project
 
 # Switch to hazdev-user
-USER hazdev-user
+#USER hazdev-user
 
 
 WORKDIR /hazdev-project


### PR DESCRIPTION
By allowing the tests to remain in the container build, Jenkins can run the unit tests in the container after it's been built.