### PR TITLE
Fix customProbability in JSON response

### DIFF
--- a/src/lib/asce41-handler.js
+++ b/src/lib/asce41-handler.js
@@ -141,8 +141,10 @@ const ASCE41Handler = function (options) {
           Object.keys(hazardLevel).forEach((key) => {
             var value;
 
-            if (key === 'hazardLevel' || key === 'customProbability') {
+            if (key === 'hazardLevel') {
               value = hazardLevel[key];
+            } else if (key === 'customProbability') {
+              value = parseFloat(hazardLevel[key]);
             } else if (key === 'horizontalSpectrum') {
               value = NumberUtils.roundSpectrum(hazardLevel[key]);
             } else {

--- a/src/lib/web-service.js
+++ b/src/lib/web-service.js
@@ -140,7 +140,7 @@ const WebService = function (options) {
   };
 
   /**
-   * Creates a metadata object to provide in the response body. This object
+   * Creates a metadata object to provide in the request body. This object
    * contains a timestamp, request URL, and a status indicator.
    *
    * @param request {Express.Request}
@@ -149,9 +149,9 @@ const WebService = function (options) {
    *     Is this response representing a successful request?
    *
    * @return {Object}
-   *     An object with metadata information about the response.
+   *     An object with metadata information about the request.
    */
-  _this.getResponseMetadata = function (request, isSuccess) {
+  _this.getRequestMetadata = function (request, isSuccess) {
     let params,
         protocol,
         referenceDocument;
@@ -162,7 +162,7 @@ const WebService = function (options) {
     referenceDocument = params.referenceDocument;
     delete params.referenceDocument;
 
-    ['latitude', 'longitude'].forEach((key) => {
+    ['latitude', 'longitude', 'customProbability'].forEach((key) => {
       if (params.hasOwnProperty(key)) {
         params[key] = parseFloat(params[key]);
       }
@@ -202,7 +202,7 @@ const WebService = function (options) {
         status;
 
     payload = {
-      request: _this.getResponseMetadata(request, false),
+      request: _this.getRequestMetadata(request, false),
       response: (err && err.message) ? err.message : 'internal server error'
     };
 
@@ -235,7 +235,7 @@ const WebService = function (options) {
     }
 
     payload = {
-      request: _this.getResponseMetadata(request, true),
+      request: _this.getRequestMetadata(request, true),
       response: data
     };
 

--- a/test/web-service.spec.js
+++ b/test/web-service.spec.js
@@ -166,7 +166,7 @@ describe('WebService test suite', () => {
     });
   });
 
-  describe('getResponseMetadata', function () {
+  describe('getRequestMetadata', function () {
     it('formats the metadata response', () => {
       let metadata,
           request,
@@ -183,7 +183,7 @@ describe('WebService test suite', () => {
       };
 
       service = WebService();
-      metadata = service.getResponseMetadata(request, true);
+      metadata = service.getRequestMetadata(request, true);
 
       expect(metadata.status).to.equal('success');
       expect(metadata.url).to.equal('protocol://hostname/url');
@@ -252,7 +252,7 @@ describe('WebService test suite', () => {
         json: sinon.spy()
       };
       service = WebService();
-      stub = sinon.stub(service, 'getResponseMetadata').callsFake(
+      stub = sinon.stub(service, 'getRequestMetadata').callsFake(
           () => { return ''; });
 
       service.onSuccess(data, request, response, null);


### PR DESCRIPTION
`customProbability` was being returned as a string in the JSON feed,
- http://localhost:8000/ws/designmaps/asce41-17.json?latitude=34&longitude=-118&siteClass=C&customProbability=0.1
- http://localhost:8000/ws/designmaps/asce41-13.json?latitude=34&longitude=-118&siteClass=C&customProbability=0.1