### PR TITLE
Fixes Issue #6 - wrong default value for site-amplification service d…

### DIFF
--- a/configurer/questions.js
+++ b/configurer/questions.js
@@ -122,6 +122,6 @@ module.exports = [
     type: 'input',
     name: 'SITE_AMPLIFICATION_SERVICE_URL',
     message: 'Web service for fetching site amplification factors',
-    default: 'https://earthquake.usgs.gov/ws/designmaps/site_amplification.json'
+    default: 'https://earthquake.usgs.gov/ws/designmaps/site-amplification.json'
   }
 ];


### PR DESCRIPTION
…efault value

The default value for SITE_AMPLIFICATION_SERVICE_URL in questions.js is:

https://earthquake.usgs.gov/ws/designmaps/site_amplification.json

The default value should be:

https://earthquake.usgs.gov/ws/designmaps/site-amplification.json